### PR TITLE
Add global and per-point timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Simple web app for tracking control over multiple capture points by several teams. Works offline in the browser with no dependencies.
 
+## Features
+
+- Global match timer with start, pause, and resume controls.
+- Individual timers for each capture point and per-team time tracking.
+- Default teams: RESISTANCE (purple) and MILITIA (gold).
+
 ## Usage
 
 Open `index.html` in any modern browser. Use the **Setup** panel to configure teams, capture points, and operator name or load one of the built‑in scenarios. Start the match and switch point owners as play progresses. All changes are logged with timestamps and can be downloaded as a `.txt` file via the *Download Log* button.

--- a/app.js
+++ b/app.js
@@ -47,14 +47,20 @@ const scenarios = [
   }
 ];
 
+const DEFAULT_TEAMS = [
+  { id: 'resistance', name: 'RESISTANCE', color: '#800080' },
+  { id: 'militia', name: 'MILITIA', color: '#FFD700' }
+];
+
 let state = {
-  teams: [],
+  teams: DEFAULT_TEAMS.map((t) => ({ ...t })),
   points: [],
   match: {
     state: 'idle',
     startedAt: null,
     pausedAt: null,
     totalPaused: 0,
+    endedAt: null,
     scenarioId: null,
     operator: ''
   }
@@ -81,6 +87,17 @@ function formatDuration(ms) {
   const m = Math.floor((s % 3600) / 60);
   const sec = s % 60;
   return (h > 0 ? h + ':' : '') + String(m).padStart(2, '0') + ':' + String(sec).padStart(2, '0');
+}
+
+function getMatchElapsed() {
+  if (!state.match.startedAt) return 0;
+  const ref =
+    state.match.state === 'ended'
+      ? state.match.endedAt || Date.now()
+      : state.match.state === 'paused'
+      ? state.match.pausedAt
+      : Date.now();
+  return ref - state.match.startedAt - state.match.totalPaused;
 }
 
 function appendLog(line) {
@@ -120,9 +137,9 @@ function resetDefaults() {
   localStorage.removeItem(STORAGE_KEY);
   localStorage.removeItem(LOG_KEY);
   state = {
-    teams: [],
+    teams: DEFAULT_TEAMS.map((t) => ({ ...t })),
     points: [],
-    match: { state: 'idle', startedAt: null, pausedAt: null, totalPaused: 0, scenarioId: null, operator: '' }
+    match: { state: 'idle', startedAt: null, pausedAt: null, totalPaused: 0, endedAt: null, scenarioId: null, operator: '' }
   };
   logBuffer = '';
   render();
@@ -148,7 +165,7 @@ function setOwner(pointId, teamId) {
     if (seg && !seg.endTs) seg.endTs = now;
   }
   point.owner = teamId;
-  if (teamId) {
+  if (teamId && state.match.state === 'running') {
     point.segments.push({ teamId, startTs: now, endTs: null });
   }
   appendLog(`${nowIso()} | CAPTURE | point=${point.label} | from=${from ? getTeam(from).name : 'Neutral'} | to=${teamId ? getTeam(teamId).name : 'Neutral'} | actor=${state.match.operator}`);
@@ -176,6 +193,7 @@ function startMatch() {
   state.match.state = 'running';
   state.match.startedAt = now;
   state.match.totalPaused = 0;
+  state.match.endedAt = null;
   // start segments for points with owners
   state.points.forEach((p) => {
     if (p.owner) {
@@ -238,6 +256,7 @@ function endMatch() {
     state.match.pausedAt = null;
   }
   state.match.state = 'ended';
+  state.match.endedAt = now;
   appendLog(`${nowIso()} | END`);
   // summary
   const totals = getTeamTotals();
@@ -278,6 +297,7 @@ function loadScenario(id) {
   state.match.startedAt = null;
   state.match.pausedAt = null;
   state.match.totalPaused = 0;
+  state.match.endedAt = null;
   appendLog(`${nowIso()} | SCENARIO | id=${sc.name}`);
   render();
   saveState();
@@ -347,16 +367,36 @@ function renderDashboard() {
     ownerEl.textContent = ownerName;
     card.appendChild(document.createElement('div')).textContent = p.label;
     card.appendChild(ownerEl);
-    // elapsed time for owner
+    // elapsed time for current owner (since last capture)
     let time = 0;
-    p.segments
-      .filter((s) => s.teamId === p.owner && !s.endTs)
-      .forEach((s) => {
-        time += now - s.startTs;
-      });
+    if (p.owner) {
+      for (let i = p.segments.length - 1; i >= 0; i--) {
+        const seg = p.segments[i];
+        if (seg.teamId !== p.owner) break;
+        const end = seg.endTs || now;
+        time += end - seg.startTs;
+      }
+    }
     const timeEl = document.createElement('div');
     timeEl.textContent = formatDuration(time);
     card.appendChild(timeEl);
+
+    // total times per team on this point
+    const totals = {};
+    state.teams.forEach((t) => (totals[t.id] = 0));
+    p.segments.forEach((s) => {
+      const end = s.endTs || now;
+      totals[s.teamId] += end - s.startTs;
+    });
+    const timesWrap = document.createElement('div');
+    timesWrap.className = 'team-times';
+    state.teams.forEach((t) => {
+      const div = document.createElement('div');
+      div.textContent = `${t.name}: ${formatDuration(totals[t.id])}`;
+      div.style.color = t.color;
+      timesWrap.appendChild(div);
+    });
+    card.appendChild(timesWrap);
     const ownerDisp = document.createElement('div');
     ownerDisp.className = 'owner-display';
     // neutral button
@@ -399,11 +439,17 @@ function renderMatchControls() {
     state.match.state === 'idle' || state.match.state === 'ended';
 }
 
+function renderGlobalTimer() {
+  const el = document.getElementById('globalTimer');
+  if (el) el.textContent = formatDuration(getMatchElapsed());
+}
+
 function render() {
   renderSetup();
   renderDashboard();
   renderTotals();
   renderMatchControls();
+  renderGlobalTimer();
 }
 
 // ---------- Initialization ----------
@@ -466,6 +512,7 @@ function initApp() {
     if (state.match.state === 'running') {
       renderDashboard();
       renderTotals();
+      renderGlobalTimer();
     }
   }, 1000);
 }

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <button id="resetBtn">Reset</button>
     <button id="downloadLogBtn">Download Log</button>
     <span id="matchStatus"></span>
+    <span id="globalTimer"></span>
   </header>
 
   <section id="setupView" class="hidden">

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,14 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
+  background: #e0ffff;
+}
+
+input,
+button {
+  border-radius: 0;
+  border: 1px solid #999;
+  box-shadow: none;
 }
 
 .controls {
@@ -9,7 +17,7 @@ body {
   flex-wrap: wrap;
   gap: 0.5rem;
   padding: 0.5rem;
-  background: #eee;
+  background: #e0ffff;
 }
 
 .controls button {
@@ -17,9 +25,13 @@ body {
   font-size: 1rem;
 }
 
+#globalTimer {
+  font-weight: bold;
+}
+
 #setupView {
   padding: 1rem;
-  background: #f7f7f7;
+  background: #e0ffff;
 }
 
 #setupView.hidden {
@@ -71,9 +83,14 @@ body {
   cursor: pointer;
 }
 
+.team-times {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+}
+
 footer#totals {
   padding: 1rem;
-  background: #eee;
+  background: #e0ffff;
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
@@ -94,6 +111,10 @@ body.high-contrast .controls {
 
 body.high-contrast #setupView {
   background: #111;
+}
+
+body.high-contrast footer#totals {
+  background: #222;
 }
 
 body.high-contrast .point-card {


### PR DESCRIPTION
## Summary
- prevent capture counters from advancing while the match is paused
- add a global match timer and per-point time tracking for each team
- flatten input/button styling to avoid 3‑D effects
- default teams: RESISTANCE (purple) and MILITIA (gold)
- switch interface backgrounds to a soft cyan for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4813ddcd08328abcc9209314b6236