### PR TITLE
Add team timestamp display and CSV import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@ Simple web app for tracking control over multiple capture points by several team
 - Global match timer with start, pause, and resume controls.
 - Individual timers for each capture point and per-team time tracking.
 - Default teams: RESISTANCE (purple) and MILITIA (gold).
+- Per-team last capture timestamps shown in military and 12-hour time.
+- Export logs as CSV or plain text and import logs from CSV.
 
 ## Usage
 
 Open `index.html` in any modern browser. Use the **Setup** panel to configure teams, capture points, and operator name or load one of the built‑in scenarios. Start the match and switch point owners as play progresses. All changes are logged with timestamps and can be downloaded as a `.txt` file via the *Download Log* button.
+
+CSV export/import buttons allow saving or loading the log in spreadsheet-friendly format.
 
 Match controls allow starting, pausing, resuming, ending, and resetting games. State is preserved in `localStorage` so reloading the page continues where you left off.

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
     <button id="endBtn" disabled>End</button>
     <button id="resetBtn">Reset</button>
     <button id="downloadLogBtn">Download Log</button>
+    <button id="exportCsvBtn">Export CSV</button>
+    <button id="importCsvBtn">Import CSV</button>
+    <input id="importCsvFile" type="file" accept=".csv" style="display:none">
     <span id="matchStatus"></span>
     <span id="globalTimer"></span>
   </header>

--- a/styles.css
+++ b/styles.css
@@ -2,7 +2,7 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
-  background: #e0ffff;
+  background: #2a3439;
 }
 
 input,
@@ -17,7 +17,7 @@ button {
   flex-wrap: wrap;
   gap: 0.5rem;
   padding: 0.5rem;
-  background: #e0ffff;
+  background: #2a3439;
 }
 
 .controls button {
@@ -31,7 +31,7 @@ button {
 
 #setupView {
   padding: 1rem;
-  background: #e0ffff;
+  background: #2a3439;
 }
 
 #setupView.hidden {
@@ -90,7 +90,7 @@ button {
 
 footer#totals {
   padding: 1rem;
-  background: #e0ffff;
+  background: #2a3439;
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- show per-team last capture timestamps in both military and 12-hour formats
- enable exporting and importing log data as CSV

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4977018448328b56114d2b9454597