### PR TITLE
Add resource and card tracking with logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Simple web app for tracking control over multiple capture points by several team
 - Default teams: RESISTANCE (purple) and MILITIA (gold).
 - Per-team last capture timestamps shown in military and 12-hour time.
 - Export logs as CSV or plain text and import logs from CSV.
+- Track team resources with automatic cash income, manual chip/cash controls,
+  and a clickable deck of cards (red for MILITIA, black for RESISTANCE).
 
 - Default capture points: Security Depot, Church Ruins, FORT Keith, Necropolis (Cemetary Gates), Forest Hill, Ranch, Oilfields, Tank City, FORT Caley, FORT Alastair, FORT Kurtis, Citadel, plus temporary blue points SHELTER, BUNKER, and CRASH SITE.
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,10 @@
     <input id="importCsvFile" type="file" accept=".csv" style="display:none">
     <span id="matchStatus"></span>
     <span id="globalTimer"></span>
+    <div id="currencyCounters"></div>
   </header>
+
+  <div id="cardBar"></div>
 
   <section id="setupView" class="hidden">
     <h2>Setup</h2>

--- a/styles.css
+++ b/styles.css
@@ -101,6 +101,42 @@ footer#totals .team-total {
   font-size: 1.1rem;
 }
 
+#currencyCounters {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.currency-team {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0.5rem;
+}
+
+.currency-team button {
+  margin-left: 0.25rem;
+}
+
+#cardBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  padding: 0.5rem;
+  justify-content: center;
+}
+
+#cardBar button {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #fff;
+  background: #fff;
+  color: #000;
+  cursor: pointer;
+}
+
+#cardBar button.claimed {
+  opacity: 0.3;
+}
+
 body.high-contrast {
   background: #000;
   color: #fff;


### PR DESCRIPTION
## Summary
- Track team cash, chips, and earned cards with persistent state
- Render currency controls and card deck UI with auto cash income every minute
- Log currency changes and card awards in exports

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b962383c83289387548975a89ea5