### PR TITLE
feat: add separators and time-based cash tracking

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -137,6 +137,13 @@ footer#totals .team-total {
   opacity: 0.3;
 }
 
+#cardBar .card-separator {
+  flex-basis: 100%;
+  border: 0;
+  border-top: 1px solid #fff;
+  margin: 0.5rem 0;
+}
+
 body.high-contrast {
   background: #000;
   color: #fff;


### PR DESCRIPTION
## Summary
- render card bar with separators between each row of card buttons
- compute each team's cash from elapsed match time and show real-time totals

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c5aa21608328abf07c8e0fd4fec7